### PR TITLE
Feature/build automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+[Bb]uild/
+libbulletc/libbulletc-Linux/libbulletc/build_32/
+libbulletc/libbulletc-Linux/libbulletc/build_64/
+
 libbulletc/libbulletc-Android/obj/
 libbulletc/libbulletc-Android/libs/
 BulletSharpPInvoke/obj/

--- a/libbulletc/src/libbulletc/btMotionState_wrap.cpp
+++ b/libbulletc/src/libbulletc/btMotionState_wrap.cpp
@@ -2,6 +2,8 @@
 
 #include "conversion.h"
 #include "btMotionState_wrap.h"
+// https://stackoverflow.com/questions/3156778/no-matching-function-for-call-to-operator-new
+#include <new>
 
 btMotionStateWrapper::btMotionStateWrapper(pMotionState_GetWorldTransform getWorldTransformCallback, pMotionState_SetWorldTransform setWorldTransformCallback, void* managedMotionStatePtr)
 {

--- a/libbulletc/src/src/LinearMath/btCpuFeatureUtility.h
+++ b/libbulletc/src/src/LinearMath/btCpuFeatureUtility.h
@@ -16,7 +16,7 @@
 #define ARM_NEON_GCC_COMPATIBILITY  1
 #include <arm_neon.h>
 #ifdef ANDROID
-  #include "/android/ndk/23.0.7599858/sources/android/cpufeatures/cpu-features.h"
+  #include "cpu-features.h"
 #endif
 #ifdef __APPLE__
   #include <sys/types.h>

--- a/libbulletc/src/src/LinearMath/btCpuFeatureUtility.h
+++ b/libbulletc/src/src/LinearMath/btCpuFeatureUtility.h
@@ -16,7 +16,7 @@
 #define ARM_NEON_GCC_COMPATIBILITY  1
 #include <arm_neon.h>
 #ifdef ANDROID
-  #include "NDK/sources/android/cpufeatures/cpu-features.h"
+  #include "/android/ndk/23.0.7599858/sources/android/cpufeatures/cpu-features.h"
 #endif
 #ifdef __APPLE__
   #include <sys/types.h>

--- a/libbulletc/src/src/LinearMath/btVector3.cpp
+++ b/libbulletc/src/src/LinearMath/btVector3.cpp
@@ -827,7 +827,7 @@ long _mindot_large( const float *vv, const float *vec, unsigned long count, floa
 #include <sys/types.h>
 
 #ifdef ANDROID
-  #include "NDK/sources/android/cpufeatures/cpu-features.h"
+  #include "/android/ndk/23.0.7599858/sources/android/cpufeatures/cpu-features.h"
 #endif
 
 #ifdef __APPLE__

--- a/libbulletc/src/src/LinearMath/btVector3.cpp
+++ b/libbulletc/src/src/LinearMath/btVector3.cpp
@@ -827,7 +827,7 @@ long _mindot_large( const float *vv, const float *vec, unsigned long count, floa
 #include <sys/types.h>
 
 #ifdef ANDROID
-  #include "/android/ndk/23.0.7599858/sources/android/cpufeatures/cpu-features.h"
+  #include "cpu-features.h"
 #endif
 
 #ifdef __APPLE__

--- a/libbulletc/src/src/LinearMath/btVector3.h
+++ b/libbulletc/src/src/LinearMath/btVector3.h
@@ -39,7 +39,9 @@ subject to the following restrictions:
 #endif
 
 
-#define BT_SHUFFLE(x,y,z,w) ((w)<<6 | (z)<<4 | (y)<<2 | (x))
+// https://stackoverflow.com/questions/58064487/xcode-11-cocos2dx-compilation-problem-argument-value-10880-is-outside-the-vali
+// #define BT_SHUFFLE(x,y,z,w) ((w)<<6 | (z)<<4 | (y)<<2 | (x))
+#define BT_SHUFFLE(x, y, z, w) (((w) << 6 | (z) << 4 | (y) << 2 | (x)) & 0xff)
 //#define bt_pshufd_ps( _a, _mask ) (__m128) _mm_shuffle_epi32((__m128i)(_a), (_mask) )
 #define bt_pshufd_ps( _a, _mask ) _mm_shuffle_ps((_a), (_a), (_mask) )
 #define bt_splat3_ps( _a, _i ) bt_pshufd_ps((_a), BT_SHUFFLE(_i,_i,_i, 3) )

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,0 +1,50 @@
+# base image
+FROM ubuntu:20.04
+
+# noninteractive mode for jdk
+ENV DEBIAN_FRONTEND noninteractive
+
+# sdkmanager variables
+ENV ANDROID_HOME /android
+ENV PATH "${ANDROID_HOME}/cmdline-tools/tools/bin/:${PATH}"
+ENV PATH "${ANDROID_HOME}/emulator/:${PATH}"
+ENV PATH "${ANDROID_HOME}/platform-tools/:${PATH}"
+
+#wget
+RUN apt-get update \
+&& apt-get install -y wget
+
+#cmake
+RUN apt-get update \
+&& apt-get install apt-transport-https ca-certificates gnupg software-properties-common wget -y \
+&& wget -qO - https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add - \
+&& apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main' \
+&& apt-get update \
+&& apt-get install cmake -y
+
+#jdk-8
+RUN apt-get update \
+&& apt-get install -y openjdk-8-jdk
+
+#unzip
+RUN apt-get install unzip -y
+
+#android sdkmanager
+RUN wget https://dl.google.com/android/repository/commandlinetools-linux-7583922_latest.zip \
+&& mkdir -p /android/cmdline-tools/ && cd /android/cmdline-tools/ \
+&& mv /commandlinetools-linux-7583922_latest.zip ./ \
+&& unzip commandlinetools-linux-7583922_latest.zip \
+&& rm commandlinetools-linux-7583922_latest.zip \
+&& mv cmdline-tools tools \
+&& sdkmanager
+
+#install ndk
+RUN yes | sdkmanager --licenses \
+&& sdkmanager --list \
+&& sdkmanager "ndk;23.0.7599858"
+
+#mingw
+RUN apt-get -y install gcc-mingw-w64-x86-64
+
+#g++
+RUN apt-get -y install g++

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -9,6 +9,10 @@ ENV ANDROID_HOME /android
 ENV PATH "${ANDROID_HOME}/cmdline-tools/tools/bin/:${PATH}"
 ENV PATH "${ANDROID_HOME}/emulator/:${PATH}"
 ENV PATH "${ANDROID_HOME}/platform-tools/:${PATH}"
+ENV PATH "${ANDROID_HOME}/ndk/23.0.7599858/:${PATH}"
+
+# required for ndk-build
+ENV NDK_PATH "/android/ndk/23.0.7599858"
 
 #wget
 RUN apt-get update \

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -48,3 +48,6 @@ RUN apt-get -y install gcc-mingw-w64-x86-64
 
 #g++
 RUN apt-get -y install g++
+
+#32bit tooling for gcc/g++
+RUN apt-get -y install gcc-multilib g++-multilib

--- a/tools/buildImage.sh
+++ b/tools/buildImage.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t bullet_build .

--- a/tools/buildNative.sh
+++ b/tools/buildNative.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Linux x64
+cd /src/libbulletc/libbulletc-Linux/libbulletc/
+mkdir build_64 && cd build_64 && cmake ../ && make
+
+mkdir -p /src/build/linux_x64/
+cp /src/libbulletc/libbulletc-Linux/libbulletc/build_64/libbulletc.so /src/build/linux_x64/
+
+# Linux x32
+cd /src/libbulletc/libbulletc-Linux/libbulletc/
+mkdir build_32 && cd build_32 && cmake -D32BIT=ON ../ && make
+
+mkdir -p /src/build/linux_x32/
+cp /src/libbulletc/libbulletc-Linux/libbulletc/build_32/libbulletc.so /src/build/linux_x32/

--- a/tools/buildNative.sh
+++ b/tools/buildNative.sh
@@ -13,3 +13,11 @@ mkdir build_32 && cd build_32 && cmake -D32BIT=ON ../ && make
 
 mkdir -p /src/build/linux_x32/
 cp /src/libbulletc/libbulletc-Linux/libbulletc/build_32/libbulletc.so /src/build/linux_x32/
+
+# Android armv7 armv8 x86
+cd /src/libbulletc/libbulletc-Android/jni/
+ndk-build 
+mkdir -p /src/build/arm_v7/ /src/build/arm_v8/ /src/build/x86/
+cp /src/libbulletc/libbulletc-Android/libs/armeabi-v7a/libbulletc.so /src/build/arm_v7/
+cp /src/libbulletc/libbulletc-Android/libs/arm64-v8a/libbulletc.so   /src/build/arm_v8/
+cp /src/libbulletc/libbulletc-Android/libs/x86/libbulletc.so         /src/build/x86/

--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.3'
+
+services:
+  bullet_build:
+    hostname: bullet_build
+    container_name: bullet_build
+    image: bullet_build
+    stdin_open: true
+    tty: true
+    volumes:
+      - ../:/src
+      - ./buildNative.sh:/buildNative.sh
+    command: /buildNative.sh


### PR DESCRIPTION
Build automation for BulletSharpPInvoke via Docker.

Linux:
- x86
- x64

Android:
- Arm v7 
- Arm v8
- x86

MacOs:
- not implemented (research needed)

Windows:
- not implemented (research needed)
- I have not found tooling for build .vcxproj projects on Linux and this may be very tricky. Maybe this project could solve this problem: https://github.com/roozbehid/dotnet-vcxproj

Steps for build:
- switch to `tools` directory
- run `buildImage.sh` this process take several minutes for the first time
- run `docker-compose up`